### PR TITLE
[WIP] Constant generics polynomial arithmetic

### DIFF
--- a/src/field/extension/gf_101_2.rs
+++ b/src/field/extension/gf_101_2.rs
@@ -68,13 +68,14 @@ impl Mul for PlutoBaseFieldExtension {
   type Output = Self;
 
   fn mul(self, rhs: Self) -> Self::Output {
-    let poly_self = Polynomial::<Monomial, PlutoBaseField>::from(self);
-    let poly_rhs = Polynomial::<Monomial, PlutoBaseField>::from(rhs);
+    let poly_self = Polynomial::<Monomial, PlutoBaseField, 1>::from(self);
+    let poly_rhs = Polynomial::<Monomial, PlutoBaseField, 1>::from(rhs);
     let poly_irred =
-      Polynomial::<Monomial, PlutoBaseField>::from(Self::IRREDUCIBLE_POLYNOMIAL_COEFFICIENTS);
-    let product = (poly_self * poly_rhs) % poly_irred;
-    let res: [PlutoBaseField; 2] =
-      array::from_fn(|i| product.coefficients.get(i).cloned().unwrap_or(PlutoBaseField::ZERO));
+      Polynomial::<Monomial, PlutoBaseField, 1>::from(Self::IRREDUCIBLE_POLYNOMIAL_COEFFICIENTS);
+    // let product = (poly_self * poly_rhs) % poly_irred;
+    let res: [PlutoBaseField; 2] = [PlutoBaseField::ZERO, PlutoBaseField::ZERO];
+    //   array::from_fn(|i| product.coefficients.get(i).cloned().unwrap_or(PlutoBaseField::ZERO));
+
     Self::new(res)
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,14 @@
 //! - Elliptic curves: Implementations of elliptic curves over finite fields, with support for
 //! operations such as point addition, scalar multiplication, and pairing operations.
 
-#![feature(const_trait_impl)]
 #![allow(incomplete_features)]
 #![feature(effects)]
+#![feature(const_trait_impl)]
 #![feature(const_mut_refs)]
 #![feature(const_for)]
 #![feature(const_option)]
+#![feature(const_cmp)]
+#![feature(derive_const)]
 #![feature(generic_const_exprs)]
 #![warn(missing_docs)]
 

--- a/src/polynomial/arithmetic.rs
+++ b/src/polynomial/arithmetic.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 /// Implements addition of two polynomials by adding their coefficients.
-impl<F: FiniteField> Add for Polynomial<Monomial, F> {
+impl<F: FiniteField, const D: usize> Add for Polynomial<Monomial, F, D> {
   type Output = Self;
 
   fn add(self, rhs: Self) -> Self {
@@ -28,33 +28,29 @@ impl<F: FiniteField> Add for Polynomial<Monomial, F> {
       .zip(rhs.coefficients.iter().chain(std::iter::repeat(&F::ZERO)))
       .map(|(&a, &b)| a + b)
       .take(d)
-      .collect();
+      .collect::<Vec<F>>()
+      .try_into()
+      .unwrap_or_else(|v: Vec<F>| panic!("Expected a Vec of length {} but it was {}", D, v.len()));
     Self { coefficients, basis: self.basis }
   }
 }
 
 /// Implements in-place addition of two polynomials by adding their coefficients.
-impl<F: FiniteField> AddAssign for Polynomial<Monomial, F> {
-  fn add_assign(&mut self, mut rhs: Self) {
-    let d = self.degree().max(rhs.degree());
-    if self.degree() < d {
-      self.coefficients.resize(d + 1, F::ZERO);
-    } else {
-      rhs.coefficients.resize(d + 1, F::ZERO);
-    }
-    for i in 0..d + 1 {
+impl<F: FiniteField, const D: usize> AddAssign for Polynomial<Monomial, F, D> {
+  fn add_assign(&mut self, rhs: Self) {
+    for i in 0..D {
       self.coefficients[i] += rhs.coefficients[i];
     }
   }
 }
 
 /// Implements summing a collection of polynomials.
-impl<F: FiniteField> Sum for Polynomial<Monomial, F> {
+impl<F: FiniteField, const D: usize> Sum for Polynomial<Monomial, F, D> {
   fn sum<I: Iterator<Item = Self>>(iter: I) -> Self { iter.reduce(|x, y| x + y).unwrap() }
 }
 
 /// Implements subtraction of two polynomials by subtracting their coefficients.
-impl<F: FiniteField> Sub for Polynomial<Monomial, F> {
+impl<F: FiniteField, const D: usize> Sub for Polynomial<Monomial, F, D> {
   type Output = Self;
 
   fn sub(self, rhs: Self) -> Self {
@@ -66,33 +62,43 @@ impl<F: FiniteField> Sub for Polynomial<Monomial, F> {
       .zip(rhs.coefficients.iter().chain(std::iter::repeat(&F::ZERO)))
       .map(|(&a, &b)| a - b)
       .take(d)
-      .collect();
+      .collect::<Vec<F>>()
+      .try_into()
+      .unwrap_or_else(|v: Vec<F>| panic!("Expected a Vec of length {} but it was {}", D, v.len()));
     Self { coefficients, basis: self.basis }
   }
 }
 
 /// Implements in-place subtraction of two polynomials by subtracting their coefficients.
-impl<F: FiniteField> SubAssign for Polynomial<Monomial, F> {
-  fn sub_assign(&mut self, mut rhs: Self) {
-    let d = self.degree().max(rhs.degree());
-    if self.degree() < d {
-      self.coefficients.resize(d + 1, F::ZERO);
-    } else {
-      rhs.coefficients.resize(d + 1, F::ZERO);
-    }
-    for i in 0..d + 1 {
+impl<F: FiniteField, const D: usize> SubAssign for Polynomial<Monomial, F, D> {
+  fn sub_assign(&mut self, rhs: Self) {
+    // let d = self.degree().max(rhs.degree());
+    // if self.degree() < d {
+    //   self.coefficients.resize(d + 1, F::ZERO);
+    // } else {
+    //   rhs.coefficients.resize(d + 1, F::ZERO);
+    // }
+    for i in 0..D {
       self.coefficients[i] -= rhs.coefficients[i];
     }
   }
 }
 
 /// Implements negation of a polynomial by negating its coefficients.
-impl<F: FiniteField> Neg for Polynomial<Monomial, F> {
+impl<F: FiniteField, const D: usize> Neg for Polynomial<Monomial, F, D> {
   type Output = Self;
 
   fn neg(self) -> Self {
     Self {
-      coefficients: self.coefficients.into_iter().map(|c| -c).collect(),
+      coefficients: self
+        .coefficients
+        .into_iter()
+        .map(|c| -c)
+        .collect::<Vec<F>>()
+        .try_into()
+        .unwrap_or_else(|v: Vec<F>| {
+          panic!("Expected a Vec of length {} but it was {}", D, v.len())
+        }),
       basis:        self.basis,
     }
   }
@@ -102,57 +108,63 @@ impl<F: FiniteField> Neg for Polynomial<Monomial, F> {
 /// $$
 /// (a_0 + a_1 x + a_2 x^2 + \ldots) \times (b_0 + b_1 x + b_2 x^2 + \ldots) = c_0 + c_1 x + c_2 x^2
 /// + \ldots $$ where $c_i = \sum_{j=0}^{i} a_j b_{i-j}$.
-impl<F: FiniteField> Mul for Polynomial<Monomial, F> {
-  type Output = Self;
+impl<F: FiniteField, const D: usize> Mul for Polynomial<Monomial, F, D>
+where [(); 2 * D - 1]:
+{
+  type Output = Polynomial<Monomial, F, { 2 * D - 1 }>;
 
-  fn mul(self, rhs: Self) -> Self {
-    let d = self.degree() + rhs.degree();
-    let mut coefficients = vec![F::ZERO; d + 1];
-    for i in 0..self.degree() + 1 {
-      for j in 0..rhs.degree() + 1 {
+  fn mul(self, rhs: Self) -> Self::Output {
+    // let d = self.degree() + rhs.degree();
+    let mut coefficients = [F::ZERO; 2 * D - 1];
+    for i in 0..D {
+      for j in 0..D {
         coefficients[i + j] += self.coefficients[i] * rhs.coefficients[j];
       }
     }
-    Self { coefficients, basis: self.basis }
+    Polynomial::<Monomial, F, { 2 * D - 1 }>::new(coefficients)
   }
 }
 
-/// Implements in-place multiplication of two polynomials by using the [`Mul`] implementation.
-impl<F: FiniteField> MulAssign for Polynomial<Monomial, F> {
-  fn mul_assign(&mut self, rhs: Self) {
-    let cloned = self.clone();
-    self.coefficients = (cloned * rhs).coefficients;
-  }
-}
+// TODO: can't mutate const with new degree, maybe any unsafe rust could help
+// /// Implements in-place multiplication of two polynomials by using the [`Mul`] implementation.
+// impl<F: FiniteField, const D: usize> MulAssign for Polynomial<Monomial, F, D>
+// where [(); 2 * D]:
+// {
+//   fn mul_assign(&mut self, rhs: Self) {
+//     let cloned = self.clone();
+//     let mul_poly: Polynomial<Monomial, F, { 2 * D }> = cloned * rhs;
+//     self.coefficients = mul_poly.coefficients;
+//   }
+// }
 
-/// Implements product of a collection of polynomials by using the [`Mul`] implementation.
-impl<F: FiniteField> Product for Polynomial<Monomial, F> {
-  fn product<I: Iterator<Item = Self>>(iter: I) -> Self { iter.reduce(|x, y| x * y).unwrap() }
-}
+// /// Implements product of a collection of polynomials by using the [`Mul`] implementation.
+// impl<F: FiniteField, const D: usize> Product for Polynomial<Monomial, F, D> {
+//   fn product<I: Iterator<Item = Self>>(iter: I) -> Self { iter.reduce(|x, y| x * y).unwrap() }
+// }
 
-/// Implements division of two polynomials by using the [`Polynomial::quotient_and_remainder`]
-/// method. Implicitly uses the Euclidean division algorithm.
-impl<F: FiniteField> Div for Polynomial<Monomial, F> {
-  type Output = Self;
+// /// Implements division of two polynomials by using the [`Polynomial::quotient_and_remainder`]
+// /// method. Implicitly uses the Euclidean division algorithm.
+// impl<F: FiniteField, const D: usize> Div for Polynomial<Monomial, F, D> {
+//   type Output = Self;
 
-  fn div(self, rhs: Self) -> Self::Output { self.quotient_and_remainder(rhs).0 }
-}
+//   fn div(self, rhs: Self) -> Self::Output { self.quotient_and_remainder(rhs).0 }
+// }
 
-/// Implements remainder of dividing two polynomials by using the
-/// [`Polynomial::quotient_and_remainder`] method. Implicitly uses the Euclidean division algorithm.
-impl<F: FiniteField> Rem for Polynomial<Monomial, F> {
-  type Output = Self;
+// /// Implements remainder of dividing two polynomials by using the
+// /// [`Polynomial::quotient_and_remainder`] method. Implicitly uses the Euclidean division
+// algorithm. impl<F: FiniteField, const D: usize> Rem for Polynomial<Monomial, F, D> {
+//   type Output = Self;
 
-  fn rem(self, rhs: Self) -> Self { self.quotient_and_remainder(rhs).1 }
-}
+//   fn rem(self, rhs: Self) -> Self { self.quotient_and_remainder(rhs).1 }
+// }
 
 #[cfg(test)]
 mod tests {
   use super::*;
 
   #[fixture]
-  fn poly_a() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>> {
-    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  fn poly_a() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4> {
+    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>::new([
       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
@@ -161,8 +173,8 @@ mod tests {
   }
 
   #[fixture]
-  fn poly_b() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>> {
-    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  fn poly_b() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5> {
+    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>::new([
       PrimeField::<{ PlutoPrime::Base as usize }>::new(5),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(6),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(7),
@@ -172,16 +184,16 @@ mod tests {
   }
 
   #[fixture]
-  fn poly_c() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>> {
-    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  fn poly_c() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2> {
+    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2>::new([
       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
     ])
   }
 
   #[fixture]
-  fn poly_d() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>> {
-    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  fn poly_d() -> Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2> {
+    Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2>::new([
       PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(4),
     ])
@@ -189,10 +201,10 @@ mod tests {
 
   #[rstest]
   fn add(
-    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>,
+    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>,
   ) {
-    assert_eq!((poly_a + poly_b).coefficients, [
+    assert_eq!((poly_b + poly_a.coefficients.into()).coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(6),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(8),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
@@ -203,11 +215,11 @@ mod tests {
 
   #[rstest]
   fn add_assign(
-    mut poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>,
+    mut poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>,
   ) {
-    poly_a += poly_b;
-    assert_eq!(poly_a.coefficients, [
+    poly_b += poly_a.coefficients.into();
+    assert_eq!(poly_b.coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(6),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(8),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
@@ -218,13 +230,13 @@ mod tests {
 
   #[rstest]
   fn sum(
-    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>,
+    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>,
   ) {
     assert_eq!(
-      [poly_a, poly_b]
+      [poly_a.coefficients.into(), poly_b]
         .into_iter()
-        .sum::<Polynomial<Monomial, PrimeField::<{ PlutoPrime::Base as usize }>>>()
+        .sum::<Polynomial<Monomial, PrimeField::<{ PlutoPrime::Base as usize }>, 5>>()
         .coefficients,
       [
         PrimeField::<{ PlutoPrime::Base as usize }>::new(6),
@@ -238,9 +250,11 @@ mod tests {
 
   #[rstest]
   fn sub(
-    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>,
+    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>,
   ) {
+    let poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5> =
+      poly_a.coefficients.into();
     assert_eq!((poly_a - poly_b).coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(97),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(97),
@@ -252,9 +266,11 @@ mod tests {
 
   #[rstest]
   fn sub_assign(
-    mut poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>,
+    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5>,
   ) {
+    let mut poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 5> =
+      poly_a.coefficients.into();
     poly_a -= poly_b;
     assert_eq!(poly_a.coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(97),
@@ -266,7 +282,7 @@ mod tests {
   }
 
   #[rstest]
-  fn neg(poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>) {
+  fn neg(poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 4>) {
     assert_eq!((-poly_a).coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(100),
       PrimeField::<{ PlutoPrime::Base as usize }>::new(99),
@@ -275,64 +291,64 @@ mod tests {
     ]);
   }
 
-  #[rstest]
-  fn div(
-    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-  ) {
-    assert_eq!((poly_a.clone() / poly_b.clone()).coefficients, [PrimeField::<
-      { PlutoPrime::Base as usize },
-    >::new(0)]);
-    assert_eq!((poly_b / poly_a).coefficients, [
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(95),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(78)
-    ]);
+  //   #[rstest]
+  //   fn div(
+  //     poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //     poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //   ) {
+  //     assert_eq!((poly_a.clone() / poly_b.clone()).coefficients, [PrimeField::<
+  //       { PlutoPrime::Base as usize },
+  //     >::new(0)]);
+  //     assert_eq!((poly_b / poly_a).coefficients, [
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(95),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(78)
+  //     ]);
 
-    let p = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-    ]);
-    let q = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-    ]);
-    let r = p / q;
-    assert_eq!(r.coefficients, [
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1)
-    ]);
-  }
+  //     let p = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //     ]);
+  //     let q = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //     ]);
+  //     let r = p / q;
+  //     assert_eq!(r.coefficients, [
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1)
+  //     ]);
+  //   }
 
-  #[rstest]
-  fn rem(
-    poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-  ) {
-    assert_eq!((poly_a.clone() % poly_b.clone()).coefficients, poly_a.coefficients);
-    assert_eq!((poly_b % poly_a).coefficients, [
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(11),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(41),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(71)
-    ]);
+  //   #[rstest]
+  //   fn rem(
+  //     poly_a: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //     poly_b: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //   ) {
+  //     assert_eq!((poly_a.clone() % poly_b.clone()).coefficients, poly_a.coefficients);
+  //     assert_eq!((poly_b % poly_a).coefficients, [
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(11),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(41),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(71)
+  //     ]);
 
-    let p = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-    ]);
-    let q = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
-    ]);
-    let r = p % q;
-    assert_eq!(r.coefficients, [PrimeField::<{ PlutoPrime::Base as usize }>::new(0)]);
-  }
+  //     let p = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(2),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //     ]);
+  //     let q = Polynomial::<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>::new(vec![
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(1),
+  //     ]);
+  //     let r = p % q;
+  //     assert_eq!(r.coefficients, [PrimeField::<{ PlutoPrime::Base as usize }>::new(0)]);
+  //   }
 
   #[rstest]
   fn mul(
-    poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+    poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2>,
+    poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>, 2>,
   ) {
     assert_eq!((poly_c * poly_d).coefficients, [
       PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
@@ -341,34 +357,34 @@ mod tests {
     ]);
   }
 
-  #[rstest]
-  fn mul_assign(
-    mut poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-  ) {
-    poly_c *= poly_d;
-    assert_eq!(poly_c.coefficients, [
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
-      PrimeField::<{ PlutoPrime::Base as usize }>::new(8)
-    ]);
-  }
+  //   #[rstest]
+  //   fn mul_assign(
+  //     mut poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //     poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //   ) {
+  //     poly_c *= poly_d;
+  //     assert_eq!(poly_c.coefficients, [
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
+  //       PrimeField::<{ PlutoPrime::Base as usize }>::new(8)
+  //     ]);
+  //   }
 
-  #[rstest]
-  fn product(
-    poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-    poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
-  ) {
-    assert_eq!(
-      [poly_c, poly_d]
-        .into_iter()
-        .product::<Polynomial<Monomial, PrimeField::<{ PlutoPrime::Base as usize }>>>()
-        .coefficients,
-      [
-        PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
-        PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
-        PrimeField::<{ PlutoPrime::Base as usize }>::new(8)
-      ]
-    );
-  }
+  //   #[rstest]
+  //   fn product(
+  //     poly_c: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //     poly_d: Polynomial<Monomial, PrimeField<{ PlutoPrime::Base as usize }>>,
+  //   ) {
+  //     assert_eq!(
+  //       [poly_c, poly_d]
+  //         .into_iter()
+  //         .product::<Polynomial<Monomial, PrimeField::<{ PlutoPrime::Base as usize }>>>()
+  //         .coefficients,
+  //       [
+  //         PrimeField::<{ PlutoPrime::Base as usize }>::new(3),
+  //         PrimeField::<{ PlutoPrime::Base as usize }>::new(10),
+  //         PrimeField::<{ PlutoPrime::Base as usize }>::new(8)
+  //       ]
+  //     );
+  //   }
 }

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -20,7 +20,7 @@
 use super::*;
 
 pub mod arithmetic;
-#[cfg(test)] mod tests;
+// #[cfg(test)] mod tests;
 
 // https://people.inf.ethz.ch/gander/papers/changing.pdf
 
@@ -29,12 +29,12 @@ pub mod arithmetic;
 /// The coefficients are stored in a vector with the zeroth degree term first.
 /// Highest degree term should be non-zero.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Polynomial<B: Basis, F: FiniteField> {
+pub struct Polynomial<B: Basis, F: FiniteField, const D: usize> {
   /// Coefficients of the polynomial in the chosen basis.
   /// These will be in either:
   /// - Increasing order of degree for [`Monomial`] basis.
   /// - Order of the nodes of the Lagrange polynomial for [`Lagrange`] basis.
-  pub coefficients: Vec<F>,
+  pub coefficients: [F; D],
 
   /// The basis of the polynomial. Additional node points are stored for [`Lagrange`] basis.
   pub basis: B,
@@ -68,7 +68,7 @@ impl<F: FiniteField> Basis for Lagrange<F> {
   type Data = Self;
 }
 
-impl<B: Basis, F: FiniteField> Polynomial<B, F> {
+impl<B: Basis, F: FiniteField, const D: usize> Polynomial<B, F, D> {
   /// A polynomial in any basis has a fixed number of independent terms.
   /// For example, in [`Monomial`] basis, the number of terms is one more than the degree of the
   /// polynomial.
@@ -81,7 +81,7 @@ impl<B: Basis, F: FiniteField> Polynomial<B, F> {
   pub fn num_terms(&self) -> usize { self.coefficients.len() }
 }
 
-impl<F: FiniteField> Polynomial<Monomial, F> {
+impl<F: FiniteField, const D: usize> Polynomial<Monomial, F, D> {
   /// Create a new polynomial in [`Monomial`] basis.
   ///
   /// ## Arguments:
@@ -92,21 +92,22 @@ impl<F: FiniteField> Polynomial<Monomial, F> {
   /// - A new polynomial in [`Monomial`] basis with the given coefficients.
   /// - The polynomial is automatically simplified to have a non-zero leading coefficient, that is
   ///   coefficient on the highest power term x^d.
-  pub fn new(coefficients: Vec<F>) -> Self {
-    let mut poly = Self { coefficients, basis: Monomial };
+  pub fn new(coefficients: [F; D]) -> Self {
+    // TODO: might not be correct
+    assert!(coefficients[D - 1] != F::ZERO, "last coefficient should be non-zero");
+    Self { coefficients, basis: Monomial }
     // Remove trailing zeros in the `coefficients` vector so that the highest degree term is
     // non-zero.
-    poly.trim_zeros();
-    poly
+    // poly.trim_zeros();
   }
 
-  fn trim_zeros(&mut self) {
-    let last_nonzero_index = self.coefficients.iter().rposition(|&c| c != F::ZERO);
-    match last_nonzero_index {
-      Some(index) => self.coefficients.truncate(index + 1),
-      None => self.coefficients.truncate(1),
-    }
-  }
+  // fn trim_zeros(&mut self) {
+  //   let last_nonzero_index = self.coefficients.iter().rposition(|&c| c != F::ZERO);
+  //   match last_nonzero_index {
+  //     Some(index) => self.coefficients.truncate(index + 1),
+  //     None => self.coefficients.truncate(1),
+  //   }
+  // }
 
   /// Gets the degree of the polynomial in the [`Monomial`] [`Basis`].
   /// ## Arguments:
@@ -114,7 +115,14 @@ impl<F: FiniteField> Polynomial<Monomial, F> {
   ///
   /// ## Returns:
   /// - The degree of the polynomial as a `usize`.
-  pub fn degree(&self) -> usize { self.coefficients.len() - 1 }
+  // pub const fn degree(&self) -> usize {
+  //   let mut i = D - 1;
+  //   while i > 0 && self.coefficients[i] == F::ZERO {
+  //     i -= 1;
+  //   }
+  //   i
+  //   // self.coefficients.len() - 1 }
+  // }
 
   /// Retrieves the coefficient on the highest degree monomial term of a polynomial in the
   /// [`Monomial`] [`Basis`].
@@ -149,12 +157,14 @@ impl<F: FiniteField> Polynomial<Monomial, F> {
   /// ## Returns:
   /// - A new polynomial in the [`Monomial`] [`Basis`] that is the result of multiplying the
   ///   polynomial by `coeff` times `x^pow`.
-  pub fn pow_mult(&self, coeff: F, pow: usize) -> Polynomial<Monomial, F> {
+  pub fn pow_mult<const pow: usize>(&self, coeff: F) -> Polynomial<Monomial, F, { D + pow }> {
     let mut coefficients = vec![F::ZERO; self.coefficients.len() + pow];
     self.coefficients.iter().enumerate().for_each(|(i, c)| {
       coefficients[i + pow] = *c * coeff;
     });
-    Polynomial::<Monomial, F>::new(coefficients)
+    Polynomial::<Monomial, F, { D + pow }>::new(coefficients.try_into().unwrap_or_else(
+      |v: Vec<F>| panic!("Expected a Vec of length {} but it was {}", D + pow, v.len()),
+    ))
   }
 
   /// [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) of two polynomials in [`Monomial`] basis.
@@ -168,34 +178,37 @@ impl<F: FiniteField> Polynomial<Monomial, F> {
   /// - A tuple of two polynomials in [`Monomial`] basis:
   ///   - The first element is the quotient polynomial.
   ///   - The second element is the remainder polynomial.
-  fn quotient_and_remainder(self, rhs: Self) -> (Self, Self) {
-    // Initial quotient value
-    let mut q = Self::new(vec![]);
+  // fn quotient_and_remainder<const D2: usize>(
+  //   self,
+  //   rhs: Polynomial<Monomial, F, D2>,
+  // ) -> (Self, Self) {
+  //   // Initial quotient value
+  //   let mut q = vec![];
 
-    // Initial remainder value is our numerator polynomial
-    let mut p = self.clone();
+  //   // Initial remainder value is our numerator polynomial
+  //   let mut p = self.coefficients.to_vec();
 
-    // Leading coefficient of the denominator
-    let c = rhs.leading_coefficient();
+  //   // Leading coefficient of the denominator
+  //   let c = rhs.leading_coefficient();
 
-    // Create quotient polynomial
-    let mut diff = p.degree() as isize - rhs.degree() as isize;
-    if diff < 0 {
-      return (Self::new(vec![F::ZERO]), p);
-    }
-    let mut q_coeffs = vec![F::ZERO; diff as usize + 1];
+  //   // Create quotient polynomial
+  //   let mut diff = D - D2;
+  //   // if diff < 0 {
+  //   //   return (Self::new(vec![F::ZERO]), p);
+  //   // }
+  //   let mut q_coeffs = vec![F::ZERO; diff as usize + 1];
 
-    // Perform the repeated long division algorithm
-    while diff >= 0 {
-      let s = p.leading_coefficient() * c.inverse().unwrap();
-      q_coeffs[diff as usize] = s;
-      p -= rhs.pow_mult(s, diff as usize);
-      p.trim_zeros();
-      diff = p.degree() as isize - rhs.degree() as isize;
-    }
-    q.coefficients = q_coeffs;
-    (q, p)
-  }
+  //   // Perform the repeated long division algorithm
+  //   while diff >= 0 {
+  //     let s = p.leading_coefficient() * c.inverse().unwrap();
+  //     q_coeffs[diff as usize] = s;
+  //     p -= rhs.pow_mult(s, diff as usize);
+  //     p.trim_zeros();
+  //     diff = p.degree() as isize - rhs.degree() as isize;
+  //   }
+  //   // let q = Polynomial<Monomial, F,
+  //   (q, p)
+  // }
 
   /// Computes the [Discrete Fourier Transform](https://en.wikipedia.org/wiki/Discrete_Fourier_transform)
   /// of the polynomial in the [`Monomial`] basis by evaluating the polynomial at the roots of
@@ -210,25 +223,60 @@ impl<F: FiniteField> Polynomial<Monomial, F> {
   /// ## Panics
   /// - This function will panic in calling [`FiniteField::primitive_root_of_unity`] if the field
   /// does not have roots of unity for the degree of the polynomial.
-  pub fn dft(&self) -> Polynomial<Lagrange<F>, F> {
+  pub fn dft(&self) -> Polynomial<Lagrange<F>, F, D> {
     let n = self.num_terms();
     let primitive_root_of_unity = F::primitive_root_of_unity(n);
 
-    Polynomial::<Lagrange<F>, F>::new(
-      (0..n)
-        .map(|i| {
-          self
-            .coefficients
-            .iter()
-            .enumerate()
-            .fold(F::ZERO, |acc, (j, &coeff)| acc + coeff * primitive_root_of_unity.pow(i * j))
-        })
-        .collect(),
+    let coeffs: Vec<F> = (0..n)
+      .map(|i| {
+        self
+          .coefficients
+          .iter()
+          .enumerate()
+          .fold(F::ZERO, |acc, (j, &coeff)| acc + coeff * primitive_root_of_unity.pow(i * j))
+      })
+      .collect();
+    Polynomial::<Lagrange<F>, F, D>::new(
+      coeffs.try_into().unwrap_or_else(|v: Vec<F>| {
+        panic!("Expected a Vec of length {} but it was {}", D, v.len())
+      }),
     )
   }
+
+  // / Computes DFT using radix-2 cooley-tukey [Fast Fourier Transform](). Converts a polynomial in
+  // / [`Monomial`] [`Basis`] to [`Lagrange`] basis by evaluating the polynomial at roots of unity.
+  // /
+  // /
+  // /
+  // / Assumes: polynomial degree is power of 2.
+  // #[cfg(feature = "fft")]
+  // pub fn fft(&self) -> Polynomial<Lagrange<F>, F> {
+  //   assert!(self.degree().is_power_of_two());
+  //   let n = self.degree();
+  //   let mut y = vec![F::ZERO; n];
+
+  //   let logn = n.ilog2();
+  //   for i in 0..n {
+  //     y[bit_reversal(i as u32, logn) as usize] = self.coefficients[i];
+  //   }
+
+  //   for i in 1..logn + 1 {}
+
+  //   Polynomial::<Lagrange<F>, F>::new(y)
+  // }
 }
 
-impl<const P: usize> Display for Polynomial<Monomial, PrimeField<P>> {
+// fn bit_reversal(mut num: u32, n: u32) -> u32 {
+//   let mut result = 0;
+//   for _ in 0..n {
+//     result <<= 1;
+//     result |= num & 1;
+//     num >>= 1;
+//   }
+//   result
+// }
+
+impl<const P: usize, const D: usize> Display for Polynomial<Monomial, PrimeField<P>, D> {
   fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
     let mut first = true;
     for (i, c) in self.coefficients.iter().enumerate() {
@@ -246,7 +294,7 @@ impl<const P: usize> Display for Polynomial<Monomial, PrimeField<P>> {
   }
 }
 
-impl<F: FiniteField> Polynomial<Lagrange<F>, F> {
+impl<F: FiniteField, const D: usize> Polynomial<Lagrange<F>, F, D> {
   /// Create a new polynomial in [`Lagrange`] basis by supplying a number of coefficients.
   /// Assumes that a field has a root of unity for the amount of terms given in the coefficients.
   ///
@@ -260,7 +308,7 @@ impl<F: FiniteField> Polynomial<Lagrange<F>, F> {
   /// ## Panics
   /// - This function will panic if the field does not have roots of unity for the length of the
   ///   polynomial.
-  pub fn new(coefficients: Vec<F>) -> Self {
+  pub fn new(coefficients: [F; D]) -> Self {
     // Check that the polynomial degree divides the field order so that there are roots of unity.
     let n = coefficients.len();
     assert_eq!((F::ORDER - 1) % n, 0);
@@ -321,7 +369,9 @@ impl<F: FiniteField> Polynomial<Lagrange<F>, F> {
   }
 }
 
-impl<const P: usize> Display for Polynomial<Lagrange<PrimeField<P>>, PrimeField<P>> {
+impl<const P: usize, const D: usize> Display
+  for Polynomial<Lagrange<PrimeField<P>>, PrimeField<P>, D>
+{
   fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
     let d = self.num_terms() - 1;
     for (idx, (coeff, node)) in self.coefficients.iter().zip(self.basis.nodes.iter()).enumerate() {
@@ -335,14 +385,23 @@ impl<const P: usize> Display for Polynomial<Lagrange<PrimeField<P>>, PrimeField<
   }
 }
 
-/// Convert from an array of field elements into a polynomial in the [`Monomial`] basis.
-impl<const N: usize, F: FiniteField> From<[F; N]> for Polynomial<Monomial, F> {
-  fn from(coeffs: [F; N]) -> Self { Self::new(coeffs.to_vec()) }
+impl<const N: usize, F: FiniteField, const D: usize> From<[F; N]> for Polynomial<Monomial, F, D> {
+  /// Convert from an array of field elements into a polynomial in the [`Monomial`] basis.
+  ///
+  /// **Note**: if new polynomial degree > old, then copy till old else pad new polynomial with zero
+  fn from(coeffs: [F; N]) -> Self {
+    let mut new_coeffs = [F::ZERO; D];
+
+    let copy_size = if N < D { N } else { D };
+    new_coeffs[..copy_size].copy_from_slice(&coeffs[..copy_size]);
+
+    Self { coefficients: new_coeffs, basis: Monomial }
+  }
 }
 
-/// Convert from an [`Ext`] field element into a polynomial in the [`Monomial`] basis.
-impl<const N: usize, const P: usize> From<GaloisField<N, P>>
-  for Polynomial<Monomial, PrimeField<P>>
+impl<const N: usize, const P: usize, const D: usize> From<GaloisField<N, P>>
+  for Polynomial<Monomial, PrimeField<P>, D>
 {
+  /// Convert from an [`Ext`] field element into a polynomial in the [`Monomial`] basis.
   fn from(ext: GaloisField<N, P>) -> Self { Self::from(ext.coeffs) }
 }

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -115,14 +115,17 @@ impl<F: FiniteField, const D: usize> Polynomial<Monomial, F, D> {
   ///
   /// ## Returns:
   /// - The degree of the polynomial as a `usize`.
-  // pub const fn degree(&self) -> usize {
-  //   let mut i = D - 1;
-  //   while i > 0 && self.coefficients[i] == F::ZERO {
-  //     i -= 1;
-  //   }
-  //   i
-  //   // self.coefficients.len() - 1 }
-  // }
+  pub const fn degree(&self) -> usize {
+    let mut i = D - 1;
+    // TODO: this doesn't work due to const PartialEq impl only added to structs and not for traits
+    // See [issue](https://github.com/rust-lang/rust/issues/92391)
+    // and [issue](https://github.com/rust-lang/rust/issues/77695)
+    while i > 0 && self.coefficients[i] == F::ZERO {
+      i -= 1;
+    }
+    i
+    // self.coefficients.len() - 1 }
+  }
 
   /// Retrieves the coefficient on the highest degree monomial term of a polynomial in the
   /// [`Monomial`] [`Basis`].


### PR DESCRIPTION
It changes the following:

really experimental

- adds degree based generic for compile time polynomial arithmetic.
- add, sub, mul working
- `degree` and `leading_coefficients` needed for `div`, but `const PartialEq` not implemented for structs currently in nightly.
    - See [issue](https://github.com/rust-lang/rust/issues/77695) and [issue](https://github.com/rust-lang/rust/issues/92391)

