### PR TITLE
feat: weil pairing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,34 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +268,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 name = "ronkathon"
 version = "0.1.0"
 dependencies = [
- "num-bigint",
  "pretty_assertions",
  "rand",
  "rstest",

--- a/math/curve.sage
+++ b/math/curve.sage
@@ -70,6 +70,8 @@ muls  = [(coefs[i] * g1SRS[i]) for i in range(4)]
 commitment = sum(muls)
 print(commitment)
 
+######################################################################
+# weil and tate Pairings
 
 k = 2
 r = 17
@@ -79,10 +81,17 @@ b = E2.random_element()
 c = E2.random_element()
 a = (a.order()//17)*a
 b = (b.order()//17)*b
+c = (c.order()//17)*c
 print("points", a, b, c)
 
 tate_sage = a.tate_pairing(b, r, k)
 print("tate pairing", tate_sage)
 
+tate_1 = a.tate_pairing(b+c, r, k)
+tate_2 = a.tate_pairing(b, r, k) * a.tate_pairing(c, r, k)
+print(tate_1, tate_2)
+
 weil_sage = a.weil_pairing(b, r)
 print("weil", weil_sage)
+
+######################################################################

--- a/math/curve.sage
+++ b/math/curve.sage
@@ -19,7 +19,7 @@ print(IntegerMod(F101, -1))
 # Lets make our elliptic curve
 E = EllipticCurve(F101, [0, 3])
 
-# lets print out the points, notice they print (x,y,z) the difference between homogenious points and affine points is that to use affine you just divide x,y by z. 
+# lets print out the points, notice they print (x,y,z) the difference between homogenious points and affine points is that to use affine you just divide x,y by z.
 # We can see here that for all points in the curve group z = 1 except the zero point at infinity. So for this field they are the same
 print(E.points())
 
@@ -32,25 +32,25 @@ R.<X> = PolynomialRing(F101)
 # lets pick x^2 + 2 which is irreducible in our field
 
 # Extended polynomial ring
-K.<X> = GF(101**2, modulus = x^2 + 2)
+F2.<X> = GF(101**2, modulus = x^2 + 2)
 
 # Curve group over polynomial ring
-E2 = EllipticCurve(K, [0, 3])
+E2 = EllipticCurve(F2, [0, 3])
 print(E2.points())
 
 # G1 is the generator for E1
 G1 = E(1,2)
 print(G1)
 
-# N is the order of the group E1    
+# N is the order of the group E1
 N = 17
 
 # G2 is the generator for E2
 G2 = E2([36, 31 *X])
 print(G2)
 
-# Now Lets generate the structured refrence string (SRS), 
-# we will use the "random" number 2 for the example but in practice it should be strong random. 
+# Now Lets generate the structured refrence string (SRS),
+# we will use the "random" number 2 for the example but in practice it should be strong random.
 # a circuit with n gates requires an SRS with at least
 # n + 5 elements as below
 # We will let it be of length 9, pythagorean triple uses 4 gates
@@ -66,8 +66,23 @@ GF17 = GF(17)
 
 coefs = [11, 11, 11, 1]
 # 11 * g1_srs[0] + 11 * g1_srs[1] + 11 * g1_srs[2] + 1 * g1_srs[3]
-muls  = [(coefs[i] * g1SRS[i]) for i in range(4)] 
+muls  = [(coefs[i] * g1SRS[i]) for i in range(4)]
 commitment = sum(muls)
 print(commitment)
 
 
+k = 2
+r = 17
+
+a = E2.random_element()
+b = E2.random_element()
+c = E2.random_element()
+a = (a.order()//17)*a
+b = (b.order()//17)*b
+print("points", a, b, c)
+
+tate_sage = a.tate_pairing(b, r, k)
+print("tate pairing", tate_sage)
+
+weil_sage = a.weil_pairing(b, r)
+print("weil", weil_sage)

--- a/src/curve/README.md
+++ b/src/curve/README.md
@@ -22,6 +22,7 @@ Investigating our curve and choice of field, we find that the curve is Type B si
 - $p = 101 \equiv 2 \mod 3$;
 It follows that $E(\mathbb{F}_{101})$ is [supersingular](https://en.wikipedia.org/wiki/Supersingular_elliptic_curve) which implies that the `PlutoCurve` has order (number of points) $n = 101 + 1 = 102$ and `PlutoExtendedCurve` has order $n^2 = 102^2 = 10404$.
 Finally, the embedding degree of the curve is $k=2$.
+- This curve has a 17-torsion subgroup calculated as largest prime factor of order of curve `102 = 17.2.3`.
 
 Since, the curve is supersingular, this allows us to define the type-1 Tate pairing $e \colon \mathbb{G}_{1} \times \mathbb{G}_{2} \to \mathbb{F}_{p^2}^{*}$ in a convenient manner, where both $\mathbb{G}_{1},\mathbb{G}_{2}\in\mathcal{G}_{1}$, i.e. the base field subgroup of r-torsion subgroup.
 
@@ -32,3 +33,33 @@ In this case, we pick $G = \mathbb{Z}_{17}$ and define our pairing as:
 $$e(P, Q) = f(P, \Psi(Q))^{(p^2-1)/r}$$
 where $f$ is the Tate pairing and $\Psi$ is the map $\Psi(x,y) = (\zeta x, y)$ where $\zeta$ is a primitive cube root of unity.
 This is due to the fact that $\Psi$ is the distortion map that maps a factor of $E(\mathbb{F}_{101^2})[17] \cong \mathbb{Z}_{17} \times \mathbb{Z}_{17}$ (which is the $17$-torsion group) to the other.
+
+## Pairing and Miller's algorithm
+
+Let's dive a little bit deeper into divisors, and miller's algorithm.
+
+Divisors  essentially are just a way to represent [zeroes and poles](https://crypto.stanford.edu/pbc/notes/elliptic/divisor.html) of a [rational function](https://crypto.stanford.edu/pbc/notes/elliptic/map.html). We are interested in divisors of functions evaluated on Elliptic curves, i.e. $\text{div}f=\sum_{P\in E} n_P(P)$.
+
+For example: let's take a function $f=x^3-8$ with $x\in\mathbb{C}$, it's divisor is written as $(f)$ and it has a zero of order 3 at $x=2$ and a pole of order 3 at $x=\infty$, thus, $(f) = 3(2) - 3(\infty)$.
+
+For an elliptic curve, a line usually intersects the curve at 3 points $P,Q,R=(P+Q)$, then the divisor is written as $(l)=(P)+(Q)+(R)-3(O)$. Note all of these divisors are degree-zero divisors as sum of their multiplicities is 0. There's another concept called **support of divisor** = $\text{supp}(D)=\{P\in E:n_P \neq 0\}$.
+
+Now, we have most of the things we need to represent tate pairing:
+
+$$
+e(P,Q)=f_P(D_Q)
+$$
+
+where $f_P$ is a rational function with $(f_P) = r(P) - r(O)$ and $D_Q$ is the divisor equivalent to $(D_Q)\sim (Q)-(O)$.
+
+### Miller's algorithm
+
+$f_{r,P}$ can be calculated as $f_{r-1,P}\cdot\frac{l_{[r-1]P,P}}{v_{rP}}$ where $l_{[m]P,P}$ is the line from $[m]P$ and $P$, and $v[m]P$ is the vertical line going from $m[P], -[m]P$. Both of these lines are used in chord-and-tangent rule in Elliptic curve group addition law.
+
+Usual naive way is impractical on where $r\sim 2^{160}$, and thus, for practical pairings, Miller's algorithm is used that has $O(\log r)$ time complexity, and uses an algorithm similar to double-and-add algorithm.
+
+## References
+Note that most of these are gross over-simplification of actual concepts and we advise you to refer to these references for further clarifications.
+
+- [Ben Lynn's Thesis](https://crypto.stanford.edu/pbc/thesis.pdf)
+- [Craig Costello's PairingsForBeginners](https://static1.squarespace.com/static/5fdbb09f31d71c1227082339/t/5ff394720493bd28278889c6/1609798774687/PairingsForBeginners.pdf)

--- a/src/curve/README.md
+++ b/src/curve/README.md
@@ -1,5 +1,5 @@
 # Curves
-Everything in `ronkathon` (and much of modern day cryptography) works with elliptic curves $E$ as primitives. 
+Everything in `ronkathon` (and much of modern day cryptography) works with elliptic curves $E$ as primitives.
 Simply put, an elliptic curve is a curve defined by the equation $y^2 = x^3 + ax + b$ where $a$ and $b$ are constants that define the curve.
 When working over a finite field so that $x, y a, b \in \mathbb{F}_q$, we put $E(\mathbb{F}_q)$ to denote the set of points on the curve over the field $\mathbb{F}_q$.
 It turns out that the set of points $E(\mathbb{F}_q)$ forms a group under a certain operation called point addition.
@@ -10,22 +10,25 @@ For the sake of `ronkathon`, we use a specific curve which we affectionately cal
 Our equation is:
 $$y^2 = x^3 + 3$$
 and we work with the field $\mathbb{F}_{p}$ and $\mathbb{F}_{p^2}$ where $p = 101$.
-Predominantly, we use the extension $\mathbb{F}_{p^2}$ since we need this for the [Tate pairing](https://en.wikipedia.org/wiki/Tate_pairing) operation. 
+Predominantly, we use the extension $\mathbb{F}_{p^2}$ since we need this for the [Tate pairing](https://en.wikipedia.org/wiki/Tate_pairing) operation.
 We refer to $\mathbb{F}_{101}$ as the `PlutoBaseField` and $\mathbb{F}_{101^2}$ as the `PlutoBaseFieldExtension` within `ronkathon`.
 From which, we also use the terminology of `PlutoCurve` to refer to $E(\mathbb{F}_{101})$ and `PlutoExtendedCurve` to refer to $E(\mathbb{F}_{101^2})$.
 
-### Type B
+### Type B curve and type 1 pairing
+
 Investigating our curve and choice of field, we find that the curve is Type B since:
+
 - It is of the form $y^2 = x^3 + b$;
 - $p = 101 \equiv 2 \mod 3$;
 It follows that $E(\mathbb{F}_{101})$ is [supersingular](https://en.wikipedia.org/wiki/Supersingular_elliptic_curve) which implies that the `PlutoCurve` has order (number of points) $n = 101 + 1 = 102$ and `PlutoExtendedCurve` has order $n^2 = 102^2 = 10404$.
-Finally, the embedding degree of the curve is $k=2$. 
+Finally, the embedding degree of the curve is $k=2$.
 
-This allows us to define the Tate pairing $e \colon G \times G \to \mathbb{F}_{p^2}$ in a convenient manner. 
-In particular, we can pick $G$ to be the [$r$-torsion subgroup](https://crypto.stanford.edu/pbc/notes/elliptic/torsion.html) of `PlutoCurve` where $r = 17$ is the [scalar field](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication) of the curve.
+Since, the curve is supersingular, this allows us to define the type-1 Tate pairing $e \colon \mathbb{G}_{1} \times \mathbb{G}_{2} \to \mathbb{F}_{p^2}^{*}$ in a convenient manner, where both $\mathbb{G}_{1},\mathbb{G}_{2}\in\mathcal{G}_{1}$, i.e. the base field subgroup of r-torsion subgroup.
+
+In particular, we can pick $\mathbb{G}_{1}$ to be the [$r$-torsion subgroup](https://crypto.stanford.edu/pbc/notes/elliptic/torsion.html) of `PlutoCurve` where $r = 17$ is the [scalar field](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication) of the curve.
 Note that $r=17$ is valid since $17 \nmid 101-1$ and $17 \mid 101^2 -1$ ([Balasubramanian-Koblitz theorem](https://crypto.stanford.edu/pbc/notes/ep/bk.html)).
 
 In this case, we pick $G = \mathbb{Z}_{17}$ and define our pairing as:
 $$e(P, Q) = f(P, \Psi(Q))^{(p^2-1)/r}$$
 where $f$ is the Tate pairing and $\Psi$ is the map $\Psi(x,y) = (\zeta x, y)$ where $\zeta$ is a primitive cube root of unity.
-This is due to the fact that $\Psi$ maps a factor of $E(\mathbb{F}_{101^2})[17] \cong \mathbb{Z}_{17} \times \mathbb{Z}_{17}$ (which is the $17$-torsion group) to the other.
+This is due to the fact that $\Psi$ is the distortion map that maps a factor of $E(\mathbb{F}_{101^2})[17] \cong \mathbb{Z}_{17} \times \mathbb{Z}_{17}$ (which is the $17$-torsion group) to the other.

--- a/src/curve/pluto_curve.rs
+++ b/src/curve/pluto_curve.rs
@@ -61,6 +61,25 @@ impl From<AffinePoint<PlutoBaseCurve>> for AffinePoint<PlutoExtendedCurve> {
   }
 }
 
+// TODO: have to remove const trait from finite field for this. Ask Colin or Waylon if that's
+// alright
+// impl<C: EllipticCurve> Distribution<AffinePoint<C>> for Standard {
+//   #[inline]
+//   fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AffinePoint<C> {
+//     loop {
+//       let x = C::BaseField::rand(rng);
+//       let rhs = x.pow(3) + x * C::EQUATION_A.into() + C::EQUATION_B.into();
+//       if rhs.euler_criterion() {
+//         if rand::random::<bool>() {
+//           return AffinePoint::new(x, rhs.sqrt().unwrap().0);
+//         } else {
+//           return AffinePoint::new(x, rhs.sqrt().unwrap().1);
+//         }
+//       }
+//     }
+//   }
+// }
+
 #[cfg(test)]
 mod pluto_base_curve_tests {
   use super::*;

--- a/src/field/extension/arithmetic.rs
+++ b/src/field/extension/arithmetic.rs
@@ -145,4 +145,14 @@ impl<const N: usize, const P: usize> Mul<PrimeField<P>> for GaloisField<N, P> {
 impl<const N: usize, const P: usize> MulAssign<PrimeField<P>> for GaloisField<N, P> {
   fn mul_assign(&mut self, rhs: PrimeField<P>) { *self = *self * rhs; }
 }
+
+impl<const N: usize, const P: usize> Mul<GaloisField<N, P>> for PrimeField<P> {
+  type Output = GaloisField<N, P>;
+
+  fn mul(self, rhs: GaloisField<N, P>) -> Self::Output {
+    let mut res = rhs;
+    res *= self;
+    res
+  }
+}
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/field/extension/gf_101_2.rs
+++ b/src/field/extension/gf_101_2.rs
@@ -11,9 +11,56 @@ use super::*;
 
 impl ExtensionField<2, 101> for PlutoBaseFieldExtension {
   /// irreducible polynomial used to reduce field polynomials to second degree:
-  /// F[X]/(X^2-2)
+  /// F[X]/(X^2+2)
   const IRREDUCIBLE_POLYNOMIAL_COEFFICIENTS: [PlutoBaseField; 3] =
     [PlutoBaseField::new(2), PlutoBaseField::ZERO, PlutoBaseField::ONE];
+}
+
+impl PlutoBaseFieldExtension {
+  fn norm(&self) -> PlutoBaseField {
+    let mut result = self.coeffs[0].pow(2);
+    result -= -PlutoBaseField::new(2) * self.coeffs[1].pow(2);
+    result
+  }
+
+  /// Computes euler criterion of the field element, i.e. Returns true if the element is a quadratic
+  /// residue (a square number) in the field.
+  pub fn euler_criterion(&self) -> bool { self.norm().euler_criterion() }
+
+  /// Computes square root of the field element (if it exists) and return a tuple of `(r, -r)` where
+  /// `r` is lower
+  pub fn sqrt(&self) -> Option<(Self, Self)> {
+    let (c0, c1) = (self.coeffs[0], self.coeffs[1]);
+    if c1 == PlutoBaseField::ZERO {
+      if c0.euler_criterion() {
+        return c0.sqrt().map(|(res0, res1)| (Self::from(res0), Self::from(res1)));
+      } else {
+        return c0.div(-PlutoBaseField::new(2)).sqrt().map(|(res0, res1)| {
+          (Self::new([PlutoBaseField::ZERO, res0]), Self::new([PlutoBaseField::ZERO, res1]))
+        });
+      }
+    }
+
+    let two_inv = PlutoBaseField::new(2).inverse().expect("2 should have an inverse");
+    let alpha = self.norm();
+
+    alpha.sqrt().map(|(alpha, _)| {
+      let mut delta = (alpha + c0) * two_inv;
+      if !delta.euler_criterion() {
+        delta -= alpha;
+      }
+
+      let x0 = delta.sqrt().expect("delta must have an square root").0;
+      let x0_inv = x0.inverse().expect("x0 must have an inverse");
+      let x1 = c1 * two_inv * x0_inv;
+      let x = Self::new([x0, x1]);
+      if -x < x {
+        (-x, x)
+      } else {
+        (x, -x)
+      }
+    })
+  }
 }
 
 impl FiniteField for PlutoBaseFieldExtension {
@@ -24,9 +71,9 @@ impl FiniteField for PlutoBaseFieldExtension {
   /// ```sage
   /// F = GF(101)
   /// Ft.<t> = F[]
-  /// P = Ft(t ^ 2 - 2)
+  /// P = Ft(t ^ 2 + 2)
   /// F_2 = GF(101 ^ 2, name="t", modulus=P)
-  /// f_2_primitive_element = F_2([2, 1])
+  /// f_2_primitive_element = F_2([14, 9])
   /// assert f_2_primitive_element.multiplicative_order() == 101^2-1
   /// ```
   const PRIMITIVE_ELEMENT: Self = Self::new([PlutoBaseField::new(14), PlutoBaseField::new(9)]);
@@ -59,6 +106,14 @@ impl FiniteField for PlutoBaseFieldExtension {
     } else {
       self.pow(power / 2) * self.pow(power / 2) * self
     }
+  }
+}
+
+impl<const N: usize, const P: usize> Distribution<GaloisField<N, P>> for Standard {
+  #[inline]
+  fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GaloisField<N, P> {
+    let coeffs = (0..N).map(|_| rng.gen::<PrimeField<P>>()).collect::<Vec<_>>().try_into().unwrap();
+    GaloisField::<N, P>::new(coeffs)
   }
 }
 
@@ -282,5 +337,28 @@ mod tests {
       val *= generator;
     }
     assert_eq!(val, generator);
+  }
+
+  #[test]
+  fn sqrt() {
+    let mut rng = rand::thread_rng();
+    let x = <PlutoBaseFieldExtension>::from(rng.gen::<PlutoBaseField>());
+    let x_sq = x.pow(2);
+
+    let res = x_sq.sqrt();
+    assert!(res.is_some());
+
+    assert_eq!(res.unwrap().0 * res.unwrap().0, x * x);
+
+    let x_0 = rng.gen::<PlutoBaseField>();
+    let x_1 = rng.gen::<PlutoBaseField>();
+    let x = <PlutoBaseFieldExtension>::new([x_0, x_1]);
+
+    let x_sq = x.pow(2);
+
+    let res = x_sq.sqrt();
+
+    assert!(res.is_some());
+    assert_eq!(res.unwrap().0 * res.unwrap().0, x * x);
   }
 }

--- a/src/field/extension/mod.rs
+++ b/src/field/extension/mod.rs
@@ -54,7 +54,7 @@ where [PrimeField<P>; N + 1]: {
 /// A struct that represents an element of an extension field. The element is represented as
 /// [`Monomial`] coefficients of a [`Polynomial`] of degree `N - 1` over the base [`FiniteField`]
 /// `F`.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub struct GaloisField<const N: usize, const P: usize> {
   pub(crate) coeffs: [PrimeField<P>; N],
 }

--- a/src/field/prime/mod.rs
+++ b/src/field/prime/mod.rs
@@ -41,12 +41,17 @@ impl<const P: usize> PrimeField<P> {
     Self { value: value % P }
   }
 
+  /// Computes euler criterion of the field element, i.e. Returns true if the element is a quadratic
+  /// residue (a square number) in the field.
+  pub fn euler_criterion(&self) -> bool { self.pow((P - 1) / 2).value == 1 }
+
   /// Computes the square root of a field element using the [Tonelli-Shanks algorithm](https://en.wikipedia.org/wiki/Tonelli–Shanks_algorithm).
   pub fn sqrt(&self) -> Option<(Self, Self)> {
-    assert!(self.euler_criterion(), "Element is not a quadratic residue");
     if *self == Self::ZERO {
       return Some((Self::ZERO, Self::ZERO));
     }
+
+    assert!(self.euler_criterion(), "Element is not a quadratic residue");
 
     // First define the Q and S values for the prime number P.
     let q: usize;
@@ -95,9 +100,6 @@ impl<const P: usize> PrimeField<P> {
       r *= b;
     }
   }
-
-  /// Returns true if the element is a quadratic residue (a square number) in the field.
-  pub const fn euler_criterion(&self) -> bool { self.pow((P - 1) / 2).value == 1 }
 }
 
 impl<const P: usize> const FiniteField for PrimeField<P> {
@@ -340,6 +342,7 @@ mod tests {
   #[case(PlutoBaseField::new(4), (PlutoBaseField::new(2), PlutoBaseField::new(99)))]
   #[case(PlutoBaseField::new(5), (PlutoBaseField::new(45), PlutoBaseField::new(56)))]
   #[case(PlutoBaseField::new(6), (PlutoBaseField::new(39), PlutoBaseField::new(62)))]
+  #[case(PlutoBaseField::new(0), (PlutoBaseField::new(0), PlutoBaseField::new(0)))]
   fn square_root(#[case] a: PlutoBaseField, #[case] expected: (PlutoBaseField, PlutoBaseField)) {
     assert_eq!(a.sqrt().unwrap(), expected);
   }


### PR DESCRIPTION
It changes the following:

- add `sqrt` for `PlutoBaseFieldExtension`
- add weil pairing as test harness for tate pairing
- add more docs (because why not?)
