### PR TITLE
doc: fix doc attribute scope

### DIFF
--- a/src/encryption/asymmetric/rsa/mod.rs
+++ b/src/encryption/asymmetric/rsa/mod.rs
@@ -5,9 +5,8 @@
 //! - The implementation is secure if the modulus is the product of two large random primes (they
 //!   are not random or big in these tests).
 //! - The size of the modulus should be at least 2048 bits.
-#[doc = include_str!("./README.md")]
-#[cfg(test)]
-mod tests;
+#![doc = include_str!("./README.md")]
+#[cfg(test)] mod tests;
 
 #[allow(dead_code)]
 /// Computes the modular inverse of e mod totient

--- a/src/encryption/symmetric/des/mod.rs
+++ b/src/encryption/symmetric/des/mod.rs
@@ -1,7 +1,6 @@
 //! Contains implementation of DES encryption
-#[doc = include_str!("./README.md")]
-#[cfg(test)]
-pub mod tests;
+#![doc = include_str!("./README.md")]
+#[cfg(test)] pub mod tests;
 
 pub mod constants;
 

--- a/src/hashes/mod.rs
+++ b/src/hashes/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module contains implementations of various hashing algorithms.
 //! Currently, the only supported algorithm is SHA-256.
-#[doc = include_str!("./README.md")] pub mod sha256;
+#![doc = include_str!("./README.md")]
+pub mod sha256;
 use crate::field::FiniteField;
 pub mod poseidon;
 

--- a/src/hashes/poseidon/mod.rs
+++ b/src/hashes/poseidon/mod.rs
@@ -1,5 +1,5 @@
 //! Contains implementation of Poseidon Hash function.
-#![doc = include_str!("./README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("./README.md"))]
 #[cfg(test)] mod tests;
 
 pub mod sponge;

--- a/src/hashes/poseidon/mod.rs
+++ b/src/hashes/poseidon/mod.rs
@@ -1,7 +1,6 @@
 //! Contains implementation of Poseidon Hash function.
-#[doc = include_str!("./README.md")]
-#[cfg(test)]
-mod tests;
+#![doc = include_str!("./README.md")]
+#[cfg(test)] mod tests;
 
 pub mod sponge;
 

--- a/src/kzg/mod.rs
+++ b/src/kzg/mod.rs
@@ -1,7 +1,6 @@
 //! KZG implementation for polynomial commitments
-#[doc = include_str!("./README.md")]
-#[cfg(test)]
-mod tests;
+#![doc = include_str!("./README.md")]
+#[cfg(test)] mod tests;
 
 pub mod setup;
 pub use setup::*;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,3 +1,4 @@
 //! This module contains tree data structures that allow for proving membership.
 //! Currently it only contains a Merkle tree implementation.
-#[doc = include_str!("./README.md")] pub mod merkle;
+#![doc = include_str!("./README.md")]
+pub mod merkle;


### PR DESCRIPTION
Applying the `doc` attribute without `!` just applies it to the next item, and does not actually include the `README.md`. For example:

<img width="479" alt="Screenshot 2024-06-28 at 7 53 13 PM" src="https://github.com/pluto/ronkathon/assets/25565268/688368bc-f149-4395-a210-715fc21debd2">


This PR fixes that by using `#!` instead to apply it to the entire scope, thus actually including the contents in the README.

With this PR:

<img width="991" alt="Screenshot 2024-06-28 at 7 53 35 PM" src="https://github.com/pluto/ronkathon/assets/25565268/6103f335-d402-4b3a-b437-1d732da87fa3">


To test, run `cargo doc` within `ronkathon`.

edit: the latex rendering within the html seems janky, but this could be fixed in a followup PR.