### PR TITLE
Migrate binary field from struct to enum.

### DIFF
--- a/src/field/binary_towers/extension.rs
+++ b/src/field/binary_towers/extension.rs
@@ -300,7 +300,7 @@ pub(super) fn multiply(a: &[BinaryField], b: &[BinaryField], k: usize) -> Vec<Bi
 
   // r1r2*X_{i-2}
   // X_{i-2}: a+b*x where a, b are vectors of length K/4, with a = 0, b = 1
-  let mut x_i_high = vec![BinaryField::new(0); 1 << (k - 1)];
+  let mut x_i_high = vec![BinaryField::Zero; 1 << (k - 1)];
   x_i_high[quarterlen] = BinaryField::ONE;
   let r1r2_high = multiply(&x_i_high, &r1r2, k - 1);
 
@@ -321,9 +321,12 @@ fn add_vec(lhs: &[BinaryField], rhs: &[BinaryField]) -> Vec<BinaryField> {
 pub(super) fn to_bool_vec(mut num: u64, length: usize) -> Vec<BinaryField> {
   let mut result = Vec::new();
   while num > 0 {
-    result.push(BinaryField::new(((num & 1) != 0) as u8));
+    result.push(match num & 1 {
+      0 => BinaryField::Zero,
+      _ => BinaryField::One,
+    });
     num >>= 1;
   }
-  result.extend(std::iter::repeat(BinaryField::new(0)).take(length - result.len()));
+  result.extend(std::iter::repeat(BinaryField::Zero).take(length - result.len()));
   result
 }

--- a/src/field/binary_towers/tests.rs
+++ b/src/field/binary_towers/tests.rs
@@ -133,7 +133,7 @@ pub(super) fn num_digits(n: u64) -> usize {
 fn from_bool_vec(num: Vec<BinaryField>) -> u64 {
   let mut result: u64 = 0;
   for (i, &bit) in num.iter().rev().enumerate() {
-    if bit.0 == 1 {
+    if bit == BinaryField::One {
       result |= 1 << (num.len() - 1 - i);
     }
   }
@@ -146,20 +146,20 @@ fn from_bool_vec(num: Vec<BinaryField>) -> u64 {
 #[should_panic]
 #[case(1, 0)]
 fn binary_field_arithmetic(#[case] a: usize, #[case] b: usize) {
-  let arg1 = BinaryField::new(a as u8);
-  let arg2 = BinaryField::new(b as u8);
+  let arg1 = BinaryField::from(a);
+  let arg2 = BinaryField::from(b);
   let a_test = TestBinaryField::new(a);
   let b_test = TestBinaryField::new(b);
 
-  assert_eq!((arg1 + arg2).0, (a_test + b_test).value as u8);
+  assert_eq!((arg1 + arg2), BinaryField::from((a_test + b_test).value));
   assert_eq!(arg1 - arg2, arg1 + arg2);
-  assert_eq!((arg1 * arg2).0, (a_test * b_test).value as u8);
+  assert_eq!((arg1 * arg2), BinaryField::from((a_test * b_test).value));
 
   let inv_res = arg2.inverse();
   assert!(inv_res.is_some());
   assert_eq!(inv_res.unwrap(), arg2);
 
-  assert_eq!((arg1 / arg2).0, (a_test / b_test).value as u8);
+  assert_eq!((arg1 / arg2), BinaryField::from((a_test / b_test).value));
 }
 
 #[rstest]


### PR DESCRIPTION
Refactors `BinaryField` from being a `usize` container to a sum type of `Zero` and `One`.

Also adjusts tests and binary field extensions.
