### PR TITLE
repo: add new labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -63,5 +63,13 @@
   description: "Needs discussion or decisions"
 
 - name: "bounty 🏴‍☠️"
-  color: "#fef2c0"
+  color: "fef2c0"
   description: "Closing this rewards a bounty!"
+
+- name: "attack 🤺"
+  color: "ff2c2c"
+  description: "An attack on a given implementation"
+
+- name: "needs more information 🙋"
+  color: "ccff00"
+  description: "More needed to clarify the issue"


### PR DESCRIPTION
Adds a few more new labels to the repository and fixes `bounty` label. Namely:
- `attack`
- `needs more information`