### PR TITLE
docs: update broken links README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ to run example code.
 
 ## Primitives
 
-- [Finite Group](src/field/group.rs)
-- [Fields and Their Extensions](src/field/README.md)
-  - [Binary Fields](src/field/binary_towers/README.md)
+- [Finite Group](src/algebra/group/README.md)
+- [Fields and Their Extensions](src/algebra/field/README.md)
+  - [Binary Fields](src/algebra/field/binary_towers/README.md)
 - [Curves and Their Pairings](src/curve/README.md)
 - [Polynomials](src/polynomial/mod.rs)
 - [KZG Commitments](src/kzg/README.md)


### PR DESCRIPTION
### Description
Hi! This pull request fixes broken links in the `README.md` file by updating their paths to reflect the current directory structure. Specifically, links related to "Finite Group," "Fields and Their Extensions," and "Binary Fields" have been corrected to point to the updated locations.