### PR TITLE
fix: fix incorrect elliptic curve point initialization

### DIFF
--- a/math/curve.sage
+++ b/math/curve.sage
@@ -46,7 +46,7 @@ print(G1)
 N = 17
 
 # G2 is the generator for E2
-G2 = E2([36, 31 *X])
+G2 = E2(36, 31 * X)
 print(G2)
 
 # Now Lets generate the structured reference string (SRS),


### PR DESCRIPTION
A mistake in the way the elliptic curve point `G2` is initialized.
In SageMath, points should be defined as `E(x, y)`, not `E([x, y])`.  

**Before:**  
```python
G2 = E2([36, 31 * X])
```  
**After:**  
```python
G2 = E2(36, 31 * X)
```  
